### PR TITLE
Correct osascript output

### DIFF
--- a/lib/clock_window/oscommand.rb
+++ b/lib/clock_window/oscommand.rb
@@ -42,13 +42,13 @@ module ClockWindow
               end tell
             end tell
 
-            return {frontAppName, windowTitle}
+            return windowTitle & " - " & frontAppName
           '
         SCRIPT
 
         format = Filters.new(
-          substitutions: [ [Regexp.new(/([^,]*)[, ]{1,3}(.*)/), '\2 - \1'] ].
-            add_if(@filter_opts.has_key? :substitutions){@filter_opts.delete(:substitutions)},
+          matches: [ Regexp.new(/(.*)\n/) ].
+            add_if(@filter_opts.has_key? :matches){@filter_opts.delete(:matches)},
           **@filter_opts
         )
         [exe, format]


### PR DESCRIPTION
Fixes #9 

The string returned from osascript is now like

```
"clock_window (zsh) - iTerm"
```

(PS. I have no idea how osascript works, I'm just looking up the stuff I need to do :smirk:)
